### PR TITLE
fix: resolve preprocess metadata

### DIFF
--- a/data/output/preprocess_info.json
+++ b/data/output/preprocess_info.json
@@ -5,7 +5,8 @@
     "NaicsSector",
     "BusinessType",
     "BusinessAge",
-    "CollateralInd"
+    "CollateralInd",
+    "InterestRateBucket"
   ],
   "numerical_features": [
     "GrossApproval",
@@ -15,8 +16,12 @@
     "TermInMonths",
     "CongressionalDistrict",
     "RevolverStatus",
-    "JobsSupported"
+    "JobsSupported",
+    "GrossApprovalPerJob",
+    "SBAGuaranteedApprovalPerJob",
+    "GrossToGuaranteedApprovalRatio",
+    "ApprovalDuration"
   ],
   "n_train": 7552,
-  "n_features": 49
+  "n_features": 60
 }


### PR DESCRIPTION
## Summary
- resolve preprocess_info merge remnants
- document InterestRateBucket and derived numeric features

## Testing
- `python src/preprocess.py`
- `python -m json.tool data/output/preprocess_info.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68aca330e7848321bd96c4004b7feb61